### PR TITLE
Simplify the installation and usage on VSC

### DIFF
--- a/setup_interactive_vsc.md
+++ b/setup_interactive_vsc.md
@@ -10,105 +10,15 @@ Students at Ghent University can request a VSC account [here](https://www.ugent.
 The following sections assume that you have access to the account and can log in to the page [login.hpc.ugent.be](https://login.hpc.ugent.be).
 
 
-## Installation part A: Jupyter Extensions, needed for visualization
-
-1. Navigate to [login.hpc.ugent.be](https://login.hpc.ugent.be) and follow the steps to log in.
-
-1. In the blue top bar click `Clusters` > `login Shell Access`.
-   A new tab should open with a black screen and a welcome message from the HPC cluster,
-   containing some information on the current state of the cluster.
-
-1. Load the IPython module that will be used to run Interactive Jupyter Notebooks, by entering the following command:
-
-   ```bash
-   ml load IPython/7.26.0-GCCcore-11.2.0
-   ```
-
-   The following steps will install Jupyter extensions on top of this module,
-   which will be used for visualization and other purposes.
-
-1. Install the latest version of `pip`:
-
-   ```bash
-   pip install --upgrade pip
-   ```
-
-1. Install the Python packages of the extensions:
-
-   ```bash
-   pip install nglview jupyter_contrib_nbextensions
-   ```
-
-1. You may see some warnings related to the `PATH` variable.
-   These can be fixed by editing `.bashrc` with `nano`.
-   Execute the following command:
-
-   ```bash
-   nano ~/.bashrc
-   ```
-
-   This is a simple text editor.
-   Go with the arrow keys to the last line and add the following:
-
-   ```bash
-   export PATH="${HOME}/.local/bin:${PATH}"
-   ```
-
-   Save the file and close `nano` with the key combination `Ctrl-x` and follow instructions on screen.
-
-   Close the virtual terminal by entering the `exit` command and open a new virtual terminal.
-   Activate the IPython module again before continuing with the following steps:
-
-   ```bash
-   ml load IPython/7.26.0-GCCcore-11.2.0
-   ```
-
-1. Activate the Jupyter extensions with the following commands.
-
-   ```bash
-   jupyter contrib nbextension install --user
-   jupyter nbextension enable spellchecker/main
-   jupyter nbextension enable widgetsnbextension --user --py
-   jupyter nbextension enable nglview --py
-   ```
-
-**Note.** If you somehow made a mistake, or have remnants from previous attempts for some other reason, it may help to clean these up.
-:warning:
-The following is rather invasive and may remove more than you want.
-**When in doubt, don't do this, and ask for help instead**:
-`rm -rf ~/.local/* ~/.ipython/ ~/.jupyter/`.
-
-
-## Installation part B: OpenMM
+## Installation part A: OpenMM
 
 Follow the installation instructions in [setup_noninteractive_hpc.md](setup_noninteractive_hpc.md).
 (The test job submission can be skipped.)
 
-## Installation part C: Final steps
+## Installation part B: Final steps
 
 
 1. Start a new virtual terminal on the HPC, e.g. through [login.hpc.ugent.be](https://login.hpc.ugent.be).
-   Load the Python version in which the Jupyter Notebooks will be executed,
-   and activate the OpenMM environment:
-
-   ```bash
-   ml load IPython/7.26.0-GCCcore-11.2.0
-   m
-   conda activate py39openmm
-   ```
-
-1. The following command adds the OpenMM environment to the list of available kernels for Jupyter.
-   This new kernel can later be selected in the interactive Jupyter Notebook session.
-
-   ```bash
-   python -m ipykernel install --user --name=py39openmm
-   ```
-
-   This will configure a new kernel in `~/.local/share/jupyter/kernels/python3/py39openmm`.
-   If you ever want to uninstall this kernel, you can just remove that directory.
-
-   Note that this only works when the original kernel and the new one run the same Python version.
-   (Both 3.9 at the moment.)
 
 1. Download the notebooks for the tutorials to the `$VSC_DATA` folder of your account so that you can access them through the interactive Jupyter session later.
 
@@ -137,9 +47,14 @@ Follow the installation instructions in [setup_noninteractive_hpc.md](setup_noni
      Your session will be killed when this time has passed.
    - **Number of nodes:** always `1` in this course.
    - **Number of cores:** normally always `1`, unless you use Python libraries that can exploit multiple cores (and know how to do this).
-   - **IPython version:** `7.26.0 GCCcore 11.2.0`
-   - **Custom code:** leave empty
-   - **Extra Jupyter Arguments:** `--notebook-dir="/data/gent/4YY/vsc4YYXX"`, where `vsc4YYXX` should be replaced by your VSC ID, and `4YY` are just the first three digits of your VSC ID.
+   - **IPython version:** pick something, does not matter
+   - **Custom code:** fill in the following:
+     ```bash
+     module purge
+     eval "$(${VSC_DATA}/mambaforge/bin/conda shell.bash hook)"
+     conda activate py39openmm
+     ```
+   - **Extra Jupyter Arguments:** `--notebook-dir="${VSC_DATA}"`
    - **Extra sbatch arguments:** leave empty
    - **I would like to receive an email when the session starts:** no need to check this.
 
@@ -150,15 +65,13 @@ Follow the installation instructions in [setup_noninteractive_hpc.md](setup_noni
    Normally, you should get the following:
 
    ```
-   Your session is currently starting...
-   Please be patient as this process can take a few minutes.
+   Your session is currently starting... Please be patient as this process can take a few minutes.
    ```
 
 1. After some time, a button will appear saying `Connect to Jupyter`.
    Click this button and a Jupyter Notebook (or Lab) should open in a new tab.
 
-1. On the right side of the page, there is a tab saying `New`, click it and select the environment that you created earlier.
-   If you followed our instructions, it should be named `py39openmm`.
+1. On the right side of the page, there is a tab saying `New`. Click it.
 
 1. Enter the following two lines in the first code cell and execute it by clicking on the play button in the toolbar (or typing Shift+Enter):
 
@@ -176,10 +89,7 @@ Either use the running Notebook session from the previous section, or start a ne
 
 1. Select and open a Notebook of your choice.
    For example, to get started, open the notebook `01_first_steps/01_water.ipynb`.
-   If you are not familiar with Jupyter Notebooks, the following resources can be helpful: [Jupyter Notebook Documentation](https://jupyter-notebook.readthedocs.io/en/latest/notebook.html).
 
-1. After opening a Notebook, click `Kernel` in the menu tabs and select `Change Kernel`.
-   Choose the environment that was created previously.
-   If you followed our instructions, it should be named `py39openmm`.
+1. You should be able to run everything in the Notebook you just opened.
 
-1. Now you should be able to run everything in the Notebook you just opened.
+If you are not familiar with Jupyter Notebooks, the following resources can be helpful: [Jupyter Notebook Documentation](https://jupyter-notebook.readthedocs.io/en/latest/notebook.html).

--- a/setup_laptop.md
+++ b/setup_laptop.md
@@ -57,14 +57,10 @@ Take the following steps:
      Copy the lines below **one by one** in the Anaconda prompt.
      Do not copy comment lines starting with a `#`.
 
-   - **macOS, Linux.**
+   - **macOS, Linux and WSL.**
      Run the following commands in a virtual terminal.
      You can copy-paste all lines in one go.
      (Lines starting with `#` are comments and are ignored.)
-
-   - **WSL.**
-     Same as for macOS and Linux, except that you have to you need to add `ipywidgets=7` at the end of the `mamba create` command.
-     (This is a workaround for a WSL-specific [bug](https://github.com/nglviewer/nglview/issues/1032), not need for other platoforms)
 
    Commands to be entered:
    ```bash
@@ -73,7 +69,7 @@ Take the following steps:
    # Make a new environment for OpenMM, installing all the software, which takes some minutes.
    # The mamba create command is too long to fit on your screen.
    # Make sure you copy it completely.
-   mamba create -n py39openmm python=3.9 cudatoolkit git 'jupyterlab>=3.4.4' numpy pandas scipy matplotlib ipympl rdkit openbabel openmm mdtraj nglview pymbar pdbfixer parmed jupyter_contrib_nbextensions
+   mamba create -n py39openmm python=3.9 cudatoolkit git 'jupyterlab>=3.4.4' numpy pandas scipy matplotlib ipympl rdkit openbabel openmm mdtraj nglview pymbar pdbfixer parmed jupyter_contrib_nbextensions ipywidgets=7
    # Activate the OpenMM environment
    conda activate py39openmm
    # Enable nglview and spell checker in Jupyter Notebooks.
@@ -167,8 +163,19 @@ jupyter lab
 If you are not familiar with notebooks, the following resources can be helpful:
 [Jupyter Lab Overview](https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html).
 
+## Known issues
 
-## Technical details of the problem with running OpenMM natively on Windows
+### NGLView and ipywidgets-8
+
+For NGLView to work, one should avoid installing the most recent versions of `ipywidgets` and stick to version 7.*.
+
+More details can be found here:
+
+- https://github.com/nglviewer/nglview/issues/1032
+- https://github.com/jupyter-widgets/ipywidgets/issues/3552
+
+
+### Technical details of the problem with running OpenMM natively on Windows
 
 Error message on Windows
 ```

--- a/setup_noninteractive_hpc.md
+++ b/setup_noninteractive_hpc.md
@@ -64,7 +64,7 @@ Students at Ghent University can request a VSC account [here](https://www.ugent.
    # Make a new environment for OpenMM, installing all the software, which takes some minutes.
    # The mamba create command is too long to fit on your screen.
    # Make sure you copy it completely.
-   mamba create -n py39openmm python=3.9 cudatoolkit git 'jupyterlab>=3.4.4' numpy pandas scipy matplotlib ipympl rdkit openbabel openmm mdtraj nglview pymbar pdbfixer parmed jupyter_contrib_nbextensions
+   mamba create -n py39openmm python=3.9 cudatoolkit git 'jupyterlab>=3.4.4' numpy pandas scipy matplotlib ipympl rdkit openbabel openmm mdtraj nglview pymbar pdbfixer parmed jupyter_contrib_nbextensions ipywidgets=7
    # Activate the OpenMM environment
    conda activate py39openmm
    # Enable nglview and spell checker in Jupyter Notebooks.


### PR DESCRIPTION
@jeveki After some discussion with Balazs, I got a better understanding of how the Open OnDemand Notebooks work on our cluster. Our installation procedure can be simplified a lot. This PR removes about half of the instructions, and results in a more robust setup. Can you check if this is reproducible?

For this to work, you need to make sure there are no interfereing Py packages in `~/.local`, e.g. from the previous version of the instructions.

(It should also be possible to ditch conda altogether, but that is still not working.)
